### PR TITLE
Add JAVA_HOME

### DIFF
--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -6,6 +6,7 @@ export PROJECTS=~/workspace
 export ORACLE_HOME=/usr/local/Cellar/instantclient-basic/12.1.0.2.0/lib
 export DYLD_LIBRARY_PATH=$ORACLE_HOME
 export LD_LIBRARY_PATH=$ORACLE_HOME
+export JAVA_HOME=$(/usr/libexec/java_home)
 
 # Stash your environment variables in ~/.localrc. This means they'll stay out
 # of your main dotfiles repository (which may be public, like this one), but


### PR DESCRIPTION
presumably you're a civilized sort of fellow who uses `brew cask install java` or similar. This sets java home and makes things like `idea .` less obnoxious. 
