### PR TITLE
fix: modernize windows boxstarter setup for WSL dev machine

### DIFF
--- a/platforms/windows/boxstarter.ps1
+++ b/platforms/windows/boxstarter.ps1
@@ -2,6 +2,15 @@
 # https://boxstarter.org/weblauncher
 # START https://boxstarter.org/package/nr/url?https://raw.githubusercontent.com/gambtho/dotfiles/refs/heads/main/platforms/windows/boxstarter.ps1
 
+function Invoke-NativeOrThrow {
+    [CmdletBinding()]
+    Param([scriptblock]$Command)
+    & $Command
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code $LASTEXITCODE: $Command"
+    }
+}
+
 function removeApp {
     Param ([string]$appName)
     Write-Host "[DEBUG] Attempting to remove app: $appName"
@@ -24,7 +33,7 @@ Write-Host "[DEBUG] Configuring Windows features and settings..."
 # Enable Developer Mode (allows symlink creation without UAC elevation)
 Write-Host "[DEBUG] Enabling Developer Mode..."
 try {
-    reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /t REG_DWORD /d 1 /f /v "AllowDevelopmentWithoutDevLicense"
+    Invoke-NativeOrThrow { reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /t REG_DWORD /d 1 /f /v "AllowDevelopmentWithoutDevLicense" }
     Write-Host "[INFO] Developer Mode enabled."
 } catch {
     Write-Host "[ERROR] Failed to enable Developer Mode: $_"
@@ -86,7 +95,7 @@ foreach ($app in $apps) {
     if (![String]::Join("", $listApp).Contains($app.name)) {
         Write-Host "[INFO] Installing: $($app.name)"
         try {
-            winget install -e --accept-source-agreements --accept-package-agreements --id $app.name
+            Invoke-NativeOrThrow { winget install -e --accept-source-agreements --accept-package-agreements --id $app.name }
             Write-Host "[INFO] Successfully installed: $($app.name)"
         } catch {
             Write-Host "[ERROR] Failed to install: $($app.name) - $_"
@@ -99,7 +108,7 @@ foreach ($app in $apps) {
 # Install Nerd Fonts (Hack) via choco — not available in winget
 Write-Host "[DEBUG] Installing Nerd Fonts via chocolatey..."
 try {
-    choco install -y nerd-fonts-hack
+    Invoke-NativeOrThrow { choco install -y nerd-fonts-hack }
     Write-Host "[INFO] Nerd Fonts installed."
 } catch {
     Write-Host "[ERROR] Failed to install Nerd Fonts: $_"
@@ -118,8 +127,8 @@ try {
 # Step 5: Enable WSL 2
 Write-Host "[DEBUG] Installing WSL 2..."
 try {
-    wsl --install
-    wsl --set-default-version 2
+    Invoke-NativeOrThrow { wsl --install }
+    Invoke-NativeOrThrow { wsl --set-default-version 2 }
     Write-Host "[INFO] WSL 2 installed and set as default. A reboot is required to complete setup."
 } catch {
     Write-Host "[ERROR] Failed to install WSL: $_"
@@ -130,7 +139,7 @@ Write-Host "[DEBUG] Configuring Windows Terminal default profile..."
 try {
     $wtSettingsPath = "$env:LOCALAPPDATA\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\settings.json"
     if (Test-Path $wtSettingsPath) {
-        $wtSettings = Get-Content $wtSettingsPath | ConvertFrom-Json
+        $wtSettings = Get-Content -Raw $wtSettingsPath | ConvertFrom-Json
         # Find the WSL profile GUID and set as default
         $wslProfile = $wtSettings.profiles.list | Where-Object { $_.name -like "*Ubuntu*" -or $_.source -like "*wsl*" } | Select-Object -First 1
         if ($wslProfile) {

--- a/platforms/windows/boxstarter.ps1
+++ b/platforms/windows/boxstarter.ps1
@@ -1,6 +1,6 @@
 # Boxstarter Script
 # https://boxstarter.org/weblauncher
-# START https://boxstarter.org/package/nr/url?https://raw.githubusercontent.com/gambtho/dotfiles/refs/heads/main/win/boxstarter.ps1
+# START https://boxstarter.org/package/nr/url?https://raw.githubusercontent.com/gambtho/dotfiles/refs/heads/main/platforms/windows/boxstarter.ps1
 
 function removeApp {
     Param ([string]$appName)
@@ -21,6 +21,15 @@ Disable-UAC
 # Step 1: Configure Windows Features and Settings
 Write-Host "[DEBUG] Configuring Windows features and settings..."
 
+# Enable Developer Mode (allows symlink creation without UAC elevation)
+Write-Host "[DEBUG] Enabling Developer Mode..."
+try {
+    reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /t REG_DWORD /d 1 /f /v "AllowDevelopmentWithoutDevLicense"
+    Write-Host "[INFO] Developer Mode enabled."
+} catch {
+    Write-Host "[ERROR] Failed to enable Developer Mode: $_"
+}
+
 # File Explorer Settings
 try {
     Set-WindowsExplorerOptions -EnableShowHiddenFilesFoldersDrives -EnableShowProtectedOSFiles -EnableShowFileExtensions
@@ -37,39 +46,27 @@ try {
 # Step 2: Remove Default Windows Applications
 Write-Host "[DEBUG] Removing unnecessary default applications..."
 $applicationList = @(
-    "Microsoft.BingFinance", "Microsoft.3DBuilder", "Microsoft.BingNews", "Microsoft.BingSports", 
-    "Microsoft.BingWeather", "Microsoft.CommsPhone", "Microsoft.Getstarted", "Microsoft.WindowsMaps",
-    "*MarchofEmpires*", "Microsoft.GetHelp", "Microsoft.Messaging", "*Minecraft*", 
-    "Microsoft.MicrosoftOfficeHub", "Microsoft.OneConnect", "Microsoft.WindowsPhone", 
-    "Microsoft.WindowsSoundRecorder", "*Solitaire*", "Microsoft.MicrosoftStickyNotes", 
-    "Microsoft.Office.Sway", "Microsoft.XboxApp", "Microsoft.XboxIdentityProvider", 
-    "Microsoft.XboxGameOverlay", "Microsoft.ZuneMusic", "Microsoft.ZuneVideo", 
-    "Microsoft.NetworkSpeedTest", "Microsoft.FreshPaint", "Microsoft.Print3D", 
-    "Microsoft.People*", "Microsoft.Microsoft3DViewer", "Microsoft.MixedReality.Portal*", 
-    "*Skype*", "*Autodesk*", "*BubbleWitch*", "king.com*", "G5*", "*Dell*", "*Facebook*", 
-    "*Keeper*", "*Netflix*", "*Twitter*", "*Plex*", "*.Duolingo-LearnLanguagesforFree", 
-    "*.EclipseManager", "ActiproSoftwareLLC.562882FEEB491", "*.AdobePhotoshopExpress"
+    "Microsoft.BingFinance", "Microsoft.BingNews", "Microsoft.BingSports",
+    "Microsoft.BingWeather", "Microsoft.GetHelp", "Microsoft.Getstarted",
+    "Microsoft.WindowsMaps", "Microsoft.Messaging", "*Minecraft*",
+    "Microsoft.MicrosoftOfficeHub", "Microsoft.OneConnect",
+    "Microsoft.WindowsSoundRecorder", "*Solitaire*", "Microsoft.MicrosoftStickyNotes",
+    "Microsoft.Office.Sway", "Microsoft.XboxApp", "Microsoft.XboxIdentityProvider",
+    "Microsoft.XboxGameOverlay", "Microsoft.ZuneMusic", "Microsoft.ZuneVideo",
+    "Microsoft.NetworkSpeedTest", "Microsoft.Print3D",
+    "Microsoft.People*", "Microsoft.Microsoft3DViewer",
+    "*Skype*", "*Autodesk*", "*BubbleWitch*", "king.com*", "G5*",
+    "*Facebook*", "*Keeper*", "*Netflix*", "*Twitter*", "*Plex*",
+    "*.Duolingo-LearnLanguagesforFree", "*.EclipseManager",
+    "ActiproSoftwareLLC.562882FEEB491", "*.AdobePhotoshopExpress"
 )
 foreach ($app in $applicationList) {
     removeApp $app
 }
 
-# Step 3: Install Developer Tools
-Write-Host "[DEBUG] Installing developer tools..."
-try {
-    choco install -y vscode git --package-parameters="'/GitAndUnixToolsOnPath /WindowsTerminal'"
-    choco install -y python sysinternals powershell-core azure-cli nerd-fonts-hack googlechrome
-    Install-Module -Force Az
-    Update-SessionEnvironment
-    Write-Host "[INFO] Installed developer tools successfully."
-} catch {
-    Write-Host "[ERROR] Failed to install developer tools: $_"
-}
-
-# Step 5: Install Additional Apps
-Write-Host "[DEBUG] Installing additional apps..."
+# Step 3: Install Developer Tools via winget
+Write-Host "[DEBUG] Installing developer tools via winget..."
 $apps = @(
-    @{name = "Dropbox.Dropbox"},
     @{name = "Git.Git"},
     @{name = "GnuPG.Gpg4win"},
     @{name = "Google.Chrome"},
@@ -80,7 +77,8 @@ $apps = @(
     @{name = "Microsoft.VisualStudioCode"},
     @{name = "Microsoft.WindowsTerminal"},
     @{name = "AgileBits.1Password"},
-    @{name = "Doist.Todoist"}
+    @{name = "Doist.Todoist"},
+    @{name = "Microsoft.AzureCLI"}
 )
 foreach ($app in $apps) {
     Write-Host "[DEBUG] Checking if app is installed: $($app.name)"
@@ -98,17 +96,58 @@ foreach ($app in $apps) {
     }
 }
 
-# Step 6: Enable Virtualization and WSL
-Write-Host "[DEBUG] Enabling virtualization and WSL..."
+# Install Nerd Fonts (Hack) via choco — not available in winget
+Write-Host "[DEBUG] Installing Nerd Fonts via chocolatey..."
 try {
-    dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart
-    dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart
-    Write-Host "[INFO] Enabled virtualization and WSL successfully."
+    choco install -y nerd-fonts-hack
+    Write-Host "[INFO] Nerd Fonts installed."
 } catch {
-    Write-Host "[ERROR] Failed to enable virtualization and WSL: $_"
+    Write-Host "[ERROR] Failed to install Nerd Fonts: $_"
 }
 
-# Step 4: Re-enable Critical Settings
+# Step 4: Install Az PowerShell module
+Write-Host "[DEBUG] Installing Az PowerShell module..."
+try {
+    Install-Module -Force Az
+    Update-SessionEnvironment
+    Write-Host "[INFO] Az module installed."
+} catch {
+    Write-Host "[ERROR] Failed to install Az module: $_"
+}
+
+# Step 5: Enable WSL 2
+Write-Host "[DEBUG] Installing WSL 2..."
+try {
+    wsl --install
+    wsl --set-default-version 2
+    Write-Host "[INFO] WSL 2 installed and set as default. A reboot is required to complete setup."
+} catch {
+    Write-Host "[ERROR] Failed to install WSL: $_"
+}
+
+# Step 6: Configure Windows Terminal to default to WSL
+Write-Host "[DEBUG] Configuring Windows Terminal default profile..."
+try {
+    $wtSettingsPath = "$env:LOCALAPPDATA\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\settings.json"
+    if (Test-Path $wtSettingsPath) {
+        $wtSettings = Get-Content $wtSettingsPath | ConvertFrom-Json
+        # Find the WSL profile GUID and set as default
+        $wslProfile = $wtSettings.profiles.list | Where-Object { $_.name -like "*Ubuntu*" -or $_.source -like "*wsl*" } | Select-Object -First 1
+        if ($wslProfile) {
+            $wtSettings.defaultProfile = $wslProfile.guid
+            $wtSettings | ConvertTo-Json -Depth 10 | Set-Content $wtSettingsPath
+            Write-Host "[INFO] Windows Terminal default profile set to: $($wslProfile.name)"
+        } else {
+            Write-Host "[WARN] No WSL profile found in Windows Terminal settings. Set the default profile manually."
+        }
+    } else {
+        Write-Host "[WARN] Windows Terminal settings not found at expected path. Launch it once first, then re-run this step."
+    }
+} catch {
+    Write-Host "[ERROR] Failed to configure Windows Terminal: $_"
+}
+
+# Step 7: Re-enable Critical Settings
 Write-Host "[DEBUG] Re-enabling critical settings..."
 try {
     Enable-UAC
@@ -118,4 +157,3 @@ try {
 } catch {
     Write-Host "[ERROR] Failed to re-enable critical settings: $_"
 }
-


### PR DESCRIPTION
- Replace dism WSL install with wsl --install + set-default-version 2
- Consolidate packages to winget; remove choco duplicates
- Add azure-cli via winget (Microsoft.AzureCLI)
- Remove python from choco (managed by mise in WSL)
- Remove Dropbox (not needed for WSL dev setup)
- Add Developer Mode registry key (symlinks without UAC)
- Add Windows Terminal auto-configure to default to WSL profile
- Clean up stale bloatware entries (3DBuilder, MarchofEmpires, CommsPhone, MixedReality.Portal, etc.)
- Fix sequential step numbering (was 1,2,3,5,6,4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Developer Mode enabled during setup
  * Windows Terminal auto-configured to use WSL as the default profile

* **Improvements**
  * Streamlined developer tool installation using winget with a follow-up font install
  * Refined list of default apps removed during setup
  * Updated WSL setup to a simpler install + set to WSL 2 flow
  * Az PowerShell installed earlier with improved error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->